### PR TITLE
[EN-1416] Add RPC services to Juwai-Mysql box

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,9 +5,15 @@
     dest: "{{ consul_template_home }}/config/{{ consul_template_config_file }}"
     regexp: '.*cfg$'
     mode: 0755
+  notify: supervisord update consul-template
+
+- name: supervisord update consul-template
+  command: supervisorctl update
+  when: consul_template_supervisor_enabled
   notify: supervisord restart consul-template
 
 - name: supervisord restart consul-template
-  supervisorctl: name=consul-template state=restarted
+  supervisorctl:
+    name: consul-template
+    state: restarted
   when: consul_template_supervisor_enabled
-  ignore_errors: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -34,7 +34,7 @@
     group: root
     mode: 0644
   when: consul_template_supervisor_enabled
-  notify: supervisord restart consul-template
+  notify: supervisord update consul-template
 
 - name: consul-template config main fragment
   template:


### PR DESCRIPTION
http://jira.juwai.com/browse/EN-1416

Calling update makes sure supervisord has read the config file. If trying to restart the daemon before reading the config file supervisord can shut down. I don't know why this happens. It's probably Ansible related and not supervisord's fault. Also, if config is not read, you can not start the daemon.

@imlazyone @agirivera please review
