### PR TITLE
Move juwai-admin playbook into juwai-admin repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ consul_template_group: consul
 consul_template_version: "0.10.0"
 consul_template_release: consul-template_{{ consul_template_version }}_linux_386
 consul_template_archive_file: "{{ consul_template_release }}.tar.gz"
-consul_template_download_url: "https://github.com/hashicorp/consul-template/releases/download/v{{ consul_template_version }}/{{ consul_template_archive_file }}"
+consul_template_download_url: "https://releases.hashicorp.com/consul-template/{{ consul_template_version }}/{{ consul_template_archive_file }}"
 consul_template_home: /home/{{ consul_template_user }}/consul-template
 consul_template_config_file_template: consul-template.cfg.j2
 consul_template_config_file: consul-template.cfg


### PR DESCRIPTION
Update the download URL because they removed the releases from Github.

@juwai/platform-all please review
